### PR TITLE
[8.0.r1] hal: Update and use libs based on LP64

### DIFF
--- a/audio-effects/post_proc/ma_listener.c
+++ b/audio-effects/post_proc/ma_listener.c
@@ -44,7 +44,12 @@
 
 
 #define MA_SET_STATE "audio_hw_send_qdsp_parameter"
+
+#ifdef __LP64__
+#define HAL_VENDOR_PATH "/vendor/lib64/hw"
+#else
 #define HAL_VENDOR_PATH "/vendor/lib/hw"
+#endif
 
 enum {
     MA_LISTENER_STATE_UNINITIALIZED,

--- a/audio-effects/voice_processing/voice_processing.c
+++ b/audio-effects/voice_processing/voice_processing.c
@@ -33,7 +33,11 @@
 // local definitions
 //------------------------------------------------------------------------------
 
+#ifdef __LP64__
+#define EFFECTS_DESCRIPTOR_LIBRARY_PATH "/vendor/lib64/soundfx/libqcomvoiceprocessingdescriptors.so"
+#else
 #define EFFECTS_DESCRIPTOR_LIBRARY_PATH "/vendor/lib/soundfx/libqcomvoiceprocessingdescriptors.so"
+#endif
 
 // types of pre processing modules
 enum effect_id


### PR DESCRIPTION
Update all the libs paths to support both /lib and /lib64 and pick correct one based on LP64 flag.